### PR TITLE
Add PPTX text extraction and ingestion utilities

### DIFF
--- a/app/utils/pptx_lecture_ingest.py
+++ b/app/utils/pptx_lecture_ingest.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import json
+from pptx_text_extractor import extract_pptx_to_chunks
+
+
+def categorize_pptx(path: Path) -> str:
+    """Heuristic categorization based on folder/file names."""
+    parts = [p.lower() for p in path.parts]
+    name = path.name.lower()
+
+    if "submission" in parts or "submissions" in parts or "student" in parts:
+        return "student_submission"
+    if "quiz" in parts or "assignment" in parts or "rubric" in parts:
+        return "assessment_material"
+    if "lecture" in parts or "slides" in parts or "presentation" in parts:
+        return "lecture"
+    if "meeting" in parts:
+        return "meeting"
+    return "other"
+
+
+def extract_and_categorize_all_pptx(
+    root_dir: str,
+    output_index_path: str = "cs581_pptx_index.jsonl",
+    course: str = "CS 581",
+):
+    root = Path(root_dir)
+
+    with open(output_index_path, "w", encoding="utf-8") as index_f:
+        for pptx_path in root.rglob("*.pptx"):
+            category = categorize_pptx(pptx_path)
+            chunks = extract_pptx_to_chunks(
+                pptx_path,
+                course=course,
+                lecture_id=pptx_path.stem,
+            )
+
+            for c in chunks:
+                c["metadata"]["category"] = category
+                c["metadata"]["abs_path"] = str(pptx_path)
+                index_f.write(json.dumps(c, ensure_ascii=False) + "\n")
+
+            print(f"Processed {pptx_path} as {category}")
+
+
+if __name__ == "__main__":
+    extract_and_categorize_all_pptx(
+        "/Users/dereklee/Desktop/DS549/BU MET",
+        "cs581_pptx_index.jsonl",
+        course="CS 581",
+    )

--- a/app/utils/pptx_text_extractor.py
+++ b/app/utils/pptx_text_extractor.py
@@ -1,0 +1,73 @@
+from pptx import Presentation
+from pathlib import Path
+import json
+
+def extract_pptx_to_chunks(pptx_path, course="CS 581", lecture_id=None):
+    """
+    Returns a list of RAG-ready chunks from a PowerPoint file.
+    Each chunk is one slide (optionally including notes).
+    """
+    pptx_path = Path(pptx_path)
+    prs = Presentation(pptx_path)
+
+    if lecture_id is None:
+        lecture_id = pptx_path.stem  # filename without extension
+
+    chunks = []
+
+    for slide_idx, slide in enumerate(prs.slides, start=1):
+        # Slide title (if any)
+        title_text = ""
+        if slide.shapes.title and hasattr(slide.shapes.title, "text"):
+            title_text = slide.shapes.title.text.strip()
+
+        # Body text (all text shapes except title)
+        body_parts = []
+        for shape in slide.shapes:
+            if shape == slide.shapes.title:
+                continue
+            if not hasattr(shape, "has_text_frame") or not shape.has_text_frame:
+                continue
+            text = shape.text_frame.text.strip()
+            if text:
+                body_parts.append(text)
+
+        body_text = "\n".join(body_parts).strip()
+
+        # Speaker notes (if present)
+        notes_text = ""
+        if getattr(slide, "has_notes_slide", False) and slide.notes_slide:
+            ntf = getattr(slide.notes_slide, "notes_text_frame", None)
+            if ntf:
+                notes_lines = [p.text for p in ntf.paragraphs if p.text.strip()]
+                notes_text = "\n".join(notes_lines).strip()
+
+        # Skip completely empty slides
+        if not (title_text or body_text or notes_text):
+            continue
+
+        # Combine into a single text field for RAG
+        pieces = []
+        if title_text:
+            pieces.append(f"Slide title: {title_text}")
+        if body_text:
+            pieces.append(body_text)
+        if notes_text:
+            pieces.append(f"Speaker notes:\n{notes_text}")
+
+        combined_text = "\n\n".join(pieces).strip()
+
+        chunk = {
+            "id": f"{lecture_id}_slide_{slide_idx}",
+            "text": combined_text,
+            "metadata": {
+                "course": course,
+                "lecture_id": lecture_id,
+                "source_file": pptx_path.name,
+                "slide_index": slide_idx,
+                "modality": "pptx_slide",
+            },
+        }
+        chunks.append(chunk)
+
+    return chunks


### PR DESCRIPTION
- pptx_text_extractor.py – extracts slides/notes to RAG chunks

- pptx_lecture_ingest.py – walks BU MET folder and categorizes PPTX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PowerPoint lecture file processing and indexing capability.
  * Automatically categorizes presentations into lecture, assessment, student submission, or meeting types.
  * Extracts slide content into indexed chunks with metadata for improved accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->