### PR TITLE
docs: add FEATURES_AND_FILES and SYSTEM_DESIGN

### DIFF
--- a/FEATURES_AND_FILES.md
+++ b/FEATURES_AND_FILES.md
@@ -1,0 +1,335 @@
+# Features, Research & File Catalog
+
+Companion to [`README.md`](README.md). Covers two things:
+
+1. **What we built and researched** — feature list plus the research
+   questions the eval harness was used to answer.
+2. **What every Python file in the workspace does** — one-liner per
+   module, grouped by role.
+
+For architecture, data flow, and interface diagrams see
+[`SYSTEM_DESIGN.md`](SYSTEM_DESIGN.md).
+
+---
+
+## Part 1 — Features & Research
+
+### 1.1 Product features (`ml-bu-autograder/`)
+
+| Feature | Where it lives | Notes |
+| --- | --- | --- |
+| Multimodal extraction (`pdf` / `pptx` / `xlsx` / `html`) | `app/scripts/extractors/`, `app/utils/extract_content.py` | Text, tables (Camelot), and embedded images with nearest-caption matching. |
+| Diagram describer (vision-LLM → structured JSON) | `app/scripts/vision/` (`describer.py`, `prompts.py`, `tiling.py`, `output_normalizer.py`) | Supports OpenAI, Anthropic, Gemini. Tiles oversized images. Retries on invalid JSON. |
+| Decorative-image filter | `app/scripts/image_utils/filtering.py` + `caption.py` | Drops logos/headers/icons by size, aspect ratio, and page position before the vision call. |
+| OCR fallback | `app/scripts/image_utils/ocr.py` | Tesseract-based; used when vision mode is disabled. |
+| RAG over lecture chunks | `app/scripts/retrieval/chroma_rag.py`, `app/scripts/storage/chroma_store.py`, `app/services/vector_db_service.py` | Chroma local per run; Azure Vector service as production option. |
+| Rubric-aware grading (criterion-level evidence + scores) | `app/scripts/grading/grade_submission.py` | Returns per-criterion evidence, score, and overall total. |
+| AI rubric refinement (critique → revise) | `app/services/rubric_refinement_service.py`, `app/routes/rubric_review.py` | Two-step LLM flow; enforces per-question point-sum constraint. |
+| AI rubric generation from scratch | `app/scripts/rubric_gen/generate_rubric.py` | When no rubric exists yet. |
+| Rubric test harness (Azure OpenAI E2E) | `rubric_test/rubric_test.py` | Used during the refinement validation. |
+| Token + cost tracking | `app/scripts/core/token_budget.py`, `TokenTracker` | Per-call input/output/cache tokens + USD; pricing table per model. |
+| Streamlit MVP app | `app/scripts/cli/mvp_web.py` | End-to-end grading UI with run-local Chroma. |
+| Flask alt UI | `app/scripts/web/app.py` | Minimal demo UI. |
+| FastAPI REST API + auth | `app/main.py`, `app/routes/*.py`, `app/utils/jwt_service.py` | Course / assignment / rubric / grading CRUD; JWT + PAT auth. |
+| Next.js frontend | `frontend/src/` | Instructor UI: courses, assignments, rubrics, grading, materials, settings. |
+| Azure Blob storage for course artifacts | `app/services/azure_blob_service.py` | Container layout documented in `ml-bu-autograder/README.md`. |
+| Azure-hosted vector + speech clients | `app/services/azure_vector_service.py`, `app/services/azure_speech_client.py` | Production alternatives to local Chroma / local STT. |
+| Cohere + Azure AI Inference embeddings | `app/services/azure_embedding_service.py` | `EmbeddingInputType.{SEARCH_QUERY,IMAGE,DOCUMENT}` with batching. |
+| Background material processor | `app/services/bg_material_processor.py` | Off-thread RAG + grading pipeline so API calls don't block. |
+| Unified pipeline CLI | `app/scripts/cli/run_pipeline.py` | Modes: `extract`, `describe`, `index`, `retrieve`, `grade`, `full`, `compare`. |
+
+### 1.2 Research harness contributions (root-level scripts)
+
+Built to answer concrete questions before changes are promoted into the
+product. Everything here writes a JSON results file, so results are
+reproducible and diffable.
+
+| Research question | Experiment | Result artifact |
+| --- | --- | --- |
+| Which chunking strategy (`semantic` / `fixed` / `hybrid`) gives the lowest MAE vs. professor scores on Quiz 1? | `eval_chunking_grading.py --strategies semantic fixed hybrid` | `chunking_eval_results*.json` |
+| Does few-shot calibration help on each quiz, and by how much? | `run_fewshot_comparison.py` (baseline vs. few-shot across Quiz 1–4) | `fewshot_comparison_results.json` |
+| Is OpenAI, Claude, or Gemini most aligned with the professor? | `--models openai claude gemini` | Per-model MAE in the same JSON |
+| Does restricting retrieval to the relevant module (e.g. `module1` for Quiz 1) help? | `--filter-module module1` | MAE delta vs. unfiltered |
+| Does the refined rubric (from our rubric-refinement effort) outperform the original? | Swap `--rubric` between original and `New Refined Rubrics/quiz_{N}.json` | Before/after MAE |
+| Are we leaking few-shot examples into the eval set? | Built-in leakage guard (`run_eval`'s fingerprint filter) logs removed rows per run | `Leakage guard: removed N row(s)` in stdout |
+
+### 1.3 Rubric refinement track
+
+A cross-cutting effort that produced:
+
+- **Refined rubric artifacts** under
+  `fall 2025 cs 581 quiz and assignment data/New Refined Rubrics/quiz_{1..4}/`.
+  Each folder has `rubric_refined.txt` (human) and `quiz_{N}.json`
+  (machine-readable, consumed by both tracks).
+- **Design principles** baked into each rubric:
+  objective per-point-band mappings, anchor examples at low/mid/high
+  credit, originality as a bounded separate criterion with numeric
+  thresholds, explicit non-quality signals (e.g. sentence-count is
+  administrative).
+- **Automation**: `RubricRefinementService` (critique → revise) surfaced
+  through `POST /ai_rubric_refine`, plus a standalone `rubric_gen`
+  generator for cases with no prior rubric.
+- **Validation**: `rubric_test/rubric_test.py` exercised the refined
+  rubric end-to-end against real student answers using Azure OpenAI
+  before the refinement was promoted into the product.
+
+### 1.4 Data-leakage guard
+
+- `eval_chunking_grading.py`'s `run_eval()` strips any eval row whose
+  answer text matches a registered few-shot example (80-char
+  fingerprint, stripped).
+- Assignment ID is auto-inferred from path (`_infer_assignment_id`) so
+  the guard runs in **both** baseline and few-shot conditions — the
+  comparison is apples-to-apples.
+- Provenance comments at the top of `FEW_SHOT_EXAMPLES` document the
+  source semester for every anchor (Quiz 1 anchors come from Fall 2024
+  → zero overlap; Quiz 2/3/4 use in-semester anchors but are stripped
+  from eval rows).
+
+### 1.5 Supporting research artifacts in `ml-bu-autograder/`
+
+- `Proof_of_Concept.ipynb` — initial end-to-end demo.
+- `CALIBRATION_ANALYSIS.md`, `CALIBRATION_ROOT_CAUSE.md`,
+  `CALIBRATION_DATA_INVENTORY.md` — writeups on score-calibration
+  findings.
+- `PHASE_1_SUMMARY.md` — Phase 1 deliverables summary.
+- `PROMPT_CHANGES_QUICK_REF.md` — prompt revision log.
+- `fahim-model-recommendations.md`, `research.md`, `end-to-end.md`,
+  `aseef-client-docs.md`, `frontend-documentation.md`,
+  `Josh Yip - Azure Documentation.md`, `LLM-Use-Docs+Advice.md` —
+  per-contributor writeups.
+- Experiment sandboxes: `eval/`, `pdf-extraction-tests/`,
+  `prompt-engineering-tests/`, `internet-search/`.
+
+---
+
+## Part 2 — Python File Catalog
+
+### 2.1 Root of the workspace (research harness)
+
+| File | Purpose |
+| --- | --- |
+| `eval_chunking_grading.py` | End-to-end research harness. Loads quiz Excel → builds RAG index → retrieves top-k chunks → grades with OpenAI/Claude/Gemini → compares to professor score (MAE). Hosts `FEW_SHOT_EXAMPLES`, `build_few_shot_block`, `load_rubric`, `load_eval_data`, `embed_chunks`, the data-leakage guard, and `run_eval` itself. Also exposes a CLI (`--strategies`, `--models`, `--filter-module`, `--assignment-id`, `--rubric-from-excel`, etc.). |
+| `run_fewshot_comparison.py` | Driver for Quiz 1–4 baseline-vs-few-shot comparisons. Monkey-patches `build_few_shot_block` to `""` for the baseline condition so the only difference is the calibration block. Prints a combined MAE table and writes `fewshot_comparison_results.json`. |
+| `chunking_strategies.py` | Three pure chunking functions: `chunk_by_semantic` (paragraph-boundary, size-capped), `chunk_by_fixed_tokens` (sliding window with overlap), `chunk_hybrid` (semantic first, sub-split large sections). Used by both the ingesters and `eval_chunking_grading.py`. |
+| `html_lecture_ingest.py` | Parses `.html`/`.htm` lecture exports under `Spring 2026/Lectures [html versions]/` into RAG-ready chunks (with module metadata) and writes `cs581_lecture_html_index.jsonl`. |
+| `pptx_lecture_ingest.py` | Walks `.pptx` decks and calls `pptx_text_extractor.extract_pptx_to_chunks` on each, producing `cs581_pptx_index.jsonl`. |
+| `pptx_text_extractor.py` | Slide-level extractor. Returns one RAG chunk per slide: `{id, text (title+body+speaker-notes), metadata(course, lecture_id, source_file, slide_index, modality)}`. |
+
+### 2.2 `ml-bu-autograder/app/` — FastAPI application
+
+#### 2.2.1 Entry point
+
+| File | Purpose |
+| --- | --- |
+| `app/main.py` | FastAPI app factory. Loads env, initializes Azure services (`AzureBlobService`, `LLMService`, `CohereEmbeddingService`, `ChromaDBService`, `BackgroundMaterialProcessor`), sets up CORS + validation handlers, registers all routers under `/api/v1`. |
+
+#### 2.2.2 Routes (`app/routes/`)
+
+| File | Endpoints |
+| --- | --- |
+| `auth.py` | Google OAuth + session endpoints (`/api/v1/auth/...`). |
+| `course.py` | Course CRUD. |
+| `assignment.py` | Assignment CRUD. |
+| `rubric.py` | Rubric CRUD (upload, fetch, update). |
+| `rubric_review.py` | `POST /ai_rubric_refine` — audits and revises a rubric via `RubricRefinementService`; optionally persists the critique and refined rubric to Azure Blob. |
+| `student_response.py` | Student submission CRUD. |
+| `grading.py` | Trigger grading on a student response; returns `Grade` / `GradedStudentResponse`. |
+| `course_material.py` | Upload, list, and delete course materials (lectures, etc.). |
+| `user.py` | User profile + Personal Access Token management. |
+| `__init__.py` | Router package export. |
+
+#### 2.2.3 Models (`app/models/`)
+
+Pydantic models used for request/response bodies and Azure Blob
+persistence. Each is one file:
+
+`assignment.py`, `course.py`, `course_material.py`, `grade.py`,
+`rubric.py`, `rubric_review.py` (`RubricCritique`, `RubricRefinementResponse`),
+`student_response.py`, `token.py` (PAT), `uploaded_file.py`, `user.py`.
+
+#### 2.2.4 Services (`app/services/`)
+
+| File | Purpose |
+| --- | --- |
+| `azure_blob_service.py` | Singleton wrapper over Azure Blob Storage. Implements the container layout documented in the product README (`course/{semester}/{course_id}/assignment/...`). |
+| `azure_embedding_service.py` | Two providers: `AzureEmbeddingService` (Azure AI Inference) and `CohereEmbeddingService` (Cohere v2). Exposes `EmbeddingInputType` (search query / document / image) and batches at 96 per request. |
+| `azure_vector_service.py` | Azure-hosted vector index client (alternative to local Chroma for prod). |
+| `azure_speech_client.py` | Azure AI Speech client (for audio-containing materials). |
+| `vector_db_service.py` | Abstract `VectorDBService` + concrete `ChromaDBService` (singleton) for local/per-run vector storage. |
+| `rubric_refinement_service.py` | `critique_rubric(...)` → `RubricCritique` then `refine_rubric(...)` → `Rubric`. Enforces per-question point-sum constraint in the prompt. |
+| `bg_material_processor.py` | Polls a temp directory for queued grading/embedding jobs, processes them off-thread (safe against long-running LLM calls and FastAPI worker recycling). Handles both RAG ingestion and grading pipelines. |
+| `__init__.py` | Service package exports (`AzureBlobService`, `AzureEmbeddingService`, ...). |
+
+#### 2.2.5 Utilities (`app/utils/`)
+
+| File | Purpose |
+| --- | --- |
+| `llm_service.py` | Unified LLM client (Azure OpenAI). `LLMService` singleton, `PromptBuilder`, `PromptRole`, multimodal `PromptType` (text / image / audio / file), `generate_structured_response()` for Pydantic-typed outputs. |
+| `jwt_service.py` | JWT signing/verification; `from_authorization_header` dependency used across routes. |
+| `env_var_util.py` | `get_str_var`, `get_bool_var`, `get_int_var` with required/optional semantics. |
+| `logging_util.py` | `setup_loggers(production=...)` — configures formatters and log levels. |
+| `error_handling_tpe.py` | `ErrorHandlingThreadPool` — thread pool that surfaces task exceptions instead of swallowing them. |
+| `bytes_to_doc_util.py` | `Document` dataclass + `DataType` enum; converts raw bytes into a normalized document wrapper used by RAG/grading paths. |
+| `extract_content.py` | PDF/table text+image extraction helpers (PyMuPDF + Camelot). Also has `df_to_text` table-to-readable-text converter. |
+| `describe_content.py` | `describe_diagram_with_claude` — older, simpler Anthropic-only diagram describer returning plain text (used by legacy paths; the structured JSON version is in `app/scripts/vision/`). |
+| `phase1_multimodal_extraction_util.py` | Full Phase 1 pipeline utility: PDF text-blocks + images + nearest caption, Excel sheets + embedded images, vision descriptions, optional OCR-first mode, JSONL chunks with metadata, optional direct Chroma ingestion. |
+| `pdf_extraction_docx_export_util.py` | Exports PDF extraction results to `.docx` for reviewer inspection. |
+| `pptx_text_extractor.py` | Same slide-level extractor as the root-level file (kept in-tree for the app to import without relative path hacks). |
+| `pptx_lecture_ingest.py` | In-tree copy of the root-level `.pptx` → chunks ingester. |
+| `__init__.py` | Utility package exports. |
+
+#### 2.2.6 Tests (`app/tests/`)
+
+| File | Purpose |
+| --- | --- |
+| `test_bytes_to_doc_util.py` | Round-trip tests for `Document` / `DataType` conversion. |
+
+#### 2.2.7 Deprecated (`app/to_remove/`)
+
+| File | Purpose |
+| --- | --- |
+| `rag_orchestrator.py` | Earlier RAG wrapper. |
+| `langchain_rag_service.py` | Earlier LangChain-based retrieval layer. |
+| `azure_ai_search_retriever.py` | Earlier Azure AI Search retriever. |
+
+These are superseded by `vector_db_service.py` + `bg_material_processor.py`.
+
+---
+
+### 2.3 `ml-bu-autograder/app/scripts/` — Pipeline scripts
+
+There is a near-identical copy at `ml-bu-autograder/scripts/` (repo
+root); the `app/scripts/` version is the canonical one that the app
+imports. Duplication is intentional so the CLI can run with or without
+the full FastAPI stack installed.
+
+#### 2.3.1 CLI (`scripts/cli/`)
+
+| File | Purpose |
+| --- | --- |
+| `run_pipeline.py` | Unified multimodal pipeline entry point. Modes: `extract`, `describe`, `full`, `compare`, `index`, `retrieve`, `grade`. Handles vision-provider / vision-model / prompt-version flags. |
+| `mvp_web.py` | Streamlit MVP app. Uploads a submission + rubric + assignment, runs `extract → describe → index → retrieve → grade` in a run-local working directory, and displays per-criterion results + total score. |
+
+#### 2.3.2 Core (`scripts/core/`)
+
+| File | Purpose |
+| --- | --- |
+| `config.py` | Central config. `SUPPORTED_EXTENSIONS`, `get_api_key()`, `load_environment()`, `merged_config()` (CLI args + defaults + env). |
+| `pipeline.py` | Top-level pipeline orchestration. `now_utc_iso`, `list_target_files`, extract/describe/index/retrieve/grade driver functions; wires together extractors, `VisionDescriber`, storage, and chunking. |
+| `chunking.py` | `clean_text`, `chunk_text` (character-level with word-boundary snapping), `make_sort_key`, `sha1_id` (deterministic chunk IDs). |
+| `token_budget.py` | `TokenTracker` + `MODEL_PRICING` table (USD per 1M tokens, per model, with cache rates). Handles OpenAI / Anthropic / Gemini usage schemas uniformly. Exposes helpers to compute `grading_call_cost_usd`. |
+| `__init__.py` | Core package re-exports. |
+
+#### 2.3.3 Extractors (`scripts/extractors/`)
+
+| File | Purpose |
+| --- | --- |
+| `pptx_extractor.py` | Slide → text blocks + images. Pulls captions from nearby text boxes; filters decorative images via `image_utils.filtering.is_diagram_image`; runs OCR when enabled. |
+| `pdf_extractor.py` | Page → text blocks + images + detected tables. Uses PyMuPDF for layout, Camelot for tables, and the same image-filtering / OCR path. |
+| `html_extractor.py` | Parses lecture HTML. Extracts headings, paragraphs, images (with captions), and emits `ExtractedHTML` with consistent metadata. |
+| `excel_extractor.py` | Sheet → tables + embedded images. |
+| `__init__.py` | Exports `extract_{excel,html,pdf,pptx}` and `extracted_*_to_jsonable` helpers used by `pipeline.py`. |
+
+#### 2.3.4 Vision (`scripts/vision/`)
+
+| File | Purpose |
+| --- | --- |
+| `describer.py` | `VisionDescriber` class (OpenAI / Anthropic / Gemini). `describe_image_with_strategy` — handles resolution classification, tiling for oversized images, JSON-retry path, per-tile output merge, token accounting. |
+| `prompts.py` | `build_prompt()` — resolution-aware preamble + strict JSON schema (`image_type`, `all_visible_text`, `description`, `structural_elements`, `spatial_layout`, `completeness`, `unclear_parts`, `quality_warning`). Also `classify_image_quality` and `quality_warning_from_band`. |
+| `tiling.py` | `compute_tile_grid` (minimize aspect-ratio distortion, cap tile count) + `split_image_into_tiles` for oversized images. |
+| `output_normalizer.py` | `extract_json_object` (handles messy LLM output), `normalize_vision_output` (fills defaults), `merge_vision_tile_outputs`, `build_image_text_content` (flatten structured JSON into retrievable text). |
+| `__init__.py` | Vision package export. |
+
+#### 2.3.5 Image utilities (`scripts/image_utils/`)
+
+| File | Purpose |
+| --- | --- |
+| `filtering.py` | `is_diagram_image` — rejects images by area / side length / aspect ratio / page position so decorative icons never hit the vision LLM. |
+| `caption.py` | `find_best_caption_for_image` — spatial heuristic to attach the nearest text block as a caption hint. |
+| `ocr.py` | `compute_ocr` — Tesseract wrapper used when vision mode is off or as an extra signal. |
+| `__init__.py` | Package export. |
+
+#### 2.3.6 Storage (`scripts/storage/`)
+
+| File | Purpose |
+| --- | --- |
+| `chroma_store.py` | `try_store_chroma` — builds a run-local Chroma DB from JSONL chunks with metadata. |
+| `jsonl_writer.py` | `write_jsonl`, `write_json`, `write_per_file_json` — atomic JSONL and JSON writers. |
+| `__init__.py` | Storage package re-exports. |
+
+#### 2.3.7 Retrieval (`scripts/retrieval/`)
+
+| File | Purpose |
+| --- | --- |
+| `chroma_rag.py` | `read_jsonl`, `filter_chunks_by_source_type`, `ChromaRAG` dataclass for top-k retrieval with metadata filters. |
+
+#### 2.3.8 Grading (`scripts/grading/`)
+
+| File | Purpose |
+| --- | --- |
+| `grade_submission.py` | Given retrieved lecture chunks + student submission + rubric + assignment, calls the grading LLM and returns a `Grade` with per-criterion evidence, per-criterion score, and overall total. Drives the `TokenTracker`. |
+| `quiz_1_brp_prompt.py` | Quiz-1-specific grading prompt (BPR question). |
+| `regrade_quiz1_with_new_prompt.py` | One-off script to re-grade quiz 1 submissions with an updated prompt, for A/B comparison. |
+| `demo_phase1_calibration.py` | Demo/validation script for the Phase 1 calibration work. |
+| `analyze_expected_improvement.py` | Analyzes per-question expected improvement from a prompt/rubric change. |
+
+#### 2.3.9 Rubric generation (`scripts/rubric_gen/`)
+
+| File | Purpose |
+| --- | --- |
+| `generate_rubric.py` | Generate a rubric from scratch for an assignment when none exists. Companion to the refinement service (which expects an existing rubric). |
+
+#### 2.3.10 Exporters (`scripts/exporters/`)
+
+| File | Purpose |
+| --- | --- |
+| `export_pdf_extraction_docx.py` | PDF-extraction result → `.docx` for reviewer inspection. |
+| `export_pdf_layout_docx.py` | PDF layout dump (blocks + bounding boxes) → `.docx`. |
+| `export_excel_extraction_docx.py` | Excel extraction result → `.docx`. |
+
+#### 2.3.11 Visuals, tools, web, legacy
+
+| File | Purpose |
+| --- | --- |
+| `scripts/visuals/generate_phase1_visuals.py` | Builds the Phase 1 report visualizations. |
+| `scripts/tools/create_tool_comparison_matrix.py` | Builds a per-tool capability matrix (extraction/vision/grading). |
+| `scripts/web/app.py` | Flask alternative demo UI. |
+| `scripts/legacy/phase1_multimodal_pipeline.py` | Older monolithic pipeline kept for reference; superseded by `scripts/core/pipeline.py`. |
+
+### 2.4 `ml-bu-autograder/` repo-root extras
+
+| File | Purpose |
+| --- | --- |
+| `generate_jwt_secret.py` | Generates the JWT encryption secret file referenced by `JWT_ENCRYPTION_SECRET_FILE`. |
+| `rubric_test/rubric_test.py` | Azure-OpenAI-backed E2E test: parses a Quiz 1 rubric from Excel (criterion ID, rule, points, bracketed levels-of-achievement), grades the workbook's student answers, and writes `quiz1_scores.csv`. Includes `LENIENT_PERSONA` and `ROUNDING_MODE` knobs. |
+| `design/workflow_diagram.py` | Renders the project workflow diagram. |
+
+Not Python but worth flagging: `chroma.db/`, `outputs/final_phase1/…/chunks.jsonl`, `frontend/src/` (Next.js), `dataset-documentation/EDA.ipynb`, and the various `*.md` writeups referenced in Part 1.
+
+---
+
+## Conventions
+
+- Every pipeline stage writes a JSON or JSONL artifact so runs are
+  reproducible and diffable.
+- Vector storage is per-run in local mode (`chroma.db/` or
+  `outputs/.../chroma_db/`), persistent in Azure mode.
+- Grading prompts return **criterion-level** evidence + scores, never
+  just a single number.
+- Cost tracking is on by default; every grading call logs a
+  `grading_call_cost_usd` line to the persistent token log.
+- The rubric refinement flow is strictly two-step (audit → revise) and
+  the audit step is forbidden from proposing rewrites, so blame for
+  point-sum drift is localized to the revise step.
+
+---
+
+## See also
+
+- [`README.md`](README.md) — setup, quickstart, and repo tour.
+- [`SYSTEM_DESIGN.md`](SYSTEM_DESIGN.md) — architecture, data flow,
+  and interface diagrams.
+- `ml-bu-autograder/README.md` — product-side quickstart.
+- `ml-bu-autograder/MANIFEST.md` — full product-repo inventory.
+- `ml-bu-autograder/PLAN.md` — roadmap.

--- a/SYSTEM_DESIGN.md
+++ b/SYSTEM_DESIGN.md
@@ -1,0 +1,651 @@
+# System Design
+
+Companion to [`README.md`](README.md) and
+[`FEATURES_AND_FILES.md`](FEATURES_AND_FILES.md). This document covers
+architecture, data flow, component responsibilities, interfaces, and
+deployment topology for the BU MET autograder project.
+
+---
+
+## 1. Architecture Overview
+
+Two code tracks, one shared data set.
+
+```
+                        ┌──────────────────────────────────────┐
+                        │           Course Data (shared)       │
+                        │  · Lectures (Spring 2026)            │
+                        │  · Graded quizzes (Fall 2025)        │
+                        │  · Refined rubrics                   │
+                        └───────────┬─────────────┬────────────┘
+                                    │             │
+              ┌─────────────────────┘             └────────────────────┐
+              │                                                         │
+              ▼                                                         ▼
+┌────────────────────────────────────────┐      ┌────────────────────────────────────────┐
+│  Research harness  (root of workspace) │      │  Product  (`ml-bu-autograder/`)        │
+│                                        │      │                                        │
+│  eval_chunking_grading.py              │      │  FastAPI  +  Next.js  +  Streamlit     │
+│  run_fewshot_comparison.py             │      │  Pipeline CLI  (extract → describe →   │
+│  chunking_strategies.py                │ ───▶ │   index → retrieve → grade)            │
+│  html_lecture_ingest.py                │      │  Chroma (local)  /  Azure (prod)       │
+│  pptx_lecture_ingest.py                │      │  Azure Blob storage                    │
+│                                        │      │  JWT auth                              │
+│  Output: MAE per (model × strategy ×   │      │  Output: per-criterion grades +        │
+│          few-shot × rubric variant)    │      │          token/cost logs               │
+└────────────────────────────────────────┘      └────────────────────────────────────────┘
+              │                                                         ▲
+              │      calibration signals, refined rubrics,              │
+              └────▶ prompt variants, few-shot anchors ──────────────── ┘
+```
+
+Principles:
+
+1. **Two tracks, one data set.** The harness informs product decisions;
+   the product is the deliverable.
+2. **Stage-first pipeline.** Every stage writes a JSON or JSONL
+   artifact, so any stage is re-runnable in isolation and runs are
+   diffable.
+3. **Provider-agnostic LLM layer.** Any grading / vision step accepts
+   OpenAI, Anthropic, or Gemini behind a common interface.
+4. **Run-local by default, Azure-backed in production.** Same code paths,
+   different storage and auth backends.
+
+---
+
+## 2. End-to-End Data Flow (Product)
+
+```
+ ┌──────────────┐
+ │  Submission  │  (.pdf / .pptx / .xlsx / .html)
+ └──────┬───────┘
+        │
+        ▼
+ ┌────────────────────────┐     scripts/extractors/
+ │  EXTRACT               │     · text blocks
+ │  (per file type)       │     · tables (Camelot for PDF, openpyxl for xlsx)
+ │                        │     · images + nearest caption
+ └──────┬─────────────────┘     · metadata (page, slide, sheet)
+        │
+        ▼  (images only)
+ ┌────────────────────────┐     scripts/image_utils/filtering.is_diagram_image
+ │  FILTER decorative     │     · drop by size / aspect ratio / page position
+ │  images                │     · keep diagrams, flowcharts, tables, screenshots
+ └──────┬─────────────────┘
+        │
+        ▼
+ ┌────────────────────────┐     scripts/vision/describer.VisionDescriber
+ │  DESCRIBE              │     · provider ∈ {openai, anthropic, gemini}
+ │  (vision LLM)          │     · tile oversized images, merge per-tile outputs
+ │                        │     · structured JSON: image_type, all_visible_text,
+ │                        │       description, structural_elements, …
+ │                        │     · retry on invalid JSON
+ └──────┬─────────────────┘
+        │
+        ▼
+ ┌────────────────────────┐     scripts/vision/output_normalizer.build_image_text_content
+ │  FLATTEN to text       │     · turn structured JSON into retrievable text chunks
+ └──────┬─────────────────┘
+        │
+        ▼
+ ┌────────────────────────┐     scripts/core/chunking.chunk_text  (+ sha1 ids)
+ │  CHUNK                 │     · character-based, word-boundary snapped
+ │  text + flattened      │     · metadata preserved per chunk
+ │  image descriptions    │
+ └──────┬─────────────────┘
+        │
+        ▼
+ ┌────────────────────────┐     scripts/storage/chroma_store.try_store_chroma
+ │  INDEX                 │     · embed (local default / OpenAI / Gemini / Cohere)
+ │  (run-local Chroma     │     · persist under outputs/<run_id>/chroma_db
+ │  or Azure Vector)      │
+ └──────┬─────────────────┘
+        │
+        ▼
+ ┌────────────────────────┐     scripts/retrieval/chroma_rag.ChromaRAG
+ │  RETRIEVE top-k        │     · metadata filter (e.g. source_type=lecture)
+ │  lecture chunks        │     · top-k per question / per criterion
+ └──────┬─────────────────┘
+        │
+        ▼
+ ┌────────────────────────┐     scripts/grading/grade_submission.py
+ │  GRADE                 │     · rubric + assignment + retrieved context
+ │                        │     · criterion-level evidence + score
+ │                        │     · TokenTracker → input/output/cache tokens + USD
+ └──────┬─────────────────┘
+        │
+        ▼
+ ┌────────────────────────┐
+ │  Grade artifact        │     · written to outputs/<run_id>/grade.json
+ │  (returned to UI /     │     · persisted to Azure Blob in product mode
+ │   API / Blob storage)  │
+ └────────────────────────┘
+```
+
+### Research-harness flow (simpler, text-only)
+
+```
+Excel (student answers)  ──┐
+                           ├──▶  load_eval_data       ┐
+Rubric JSON             ───┘                          │
+                                                      ▼
+Lectures (HTML / PPTX) ─▶ chunking_strategies ─▶ embed_chunks ─▶ top-k retrieval
+                                                                     │
+FEW_SHOT_EXAMPLES ─▶ leakage guard (fingerprint filter) ─▶  build_few_shot_block
+                                                                     │
+                                                                     ▼
+                           grade_with_llm(provider)  ─▶  MAE vs. professor
+                                                                     │
+                                                                     ▼
+                             chunking_eval_results*.json / fewshot_comparison_results.json
+```
+
+---
+
+## 3. Subsystems
+
+### 3.1 Extraction layer
+
+- **Dispatch** (`scripts/core/pipeline.list_target_files` + per-type
+  extractors).
+- **Per-type extractors** in `scripts/extractors/`:
+  `pdf_extractor.py`, `pptx_extractor.py`, `html_extractor.py`,
+  `excel_extractor.py`.
+- **Normalized output**: `extracted_{pdf,pptx,html,excel}_to_jsonable`
+  converts the in-memory dataclasses to JSON-serializable dicts with a
+  consistent schema (text blocks, tables, images with captions,
+  metadata).
+- **Table handling**:
+  - PDF: Camelot (lattice / stream) routed through
+    `app/utils/extract_content.df_to_text`.
+  - Excel: openpyxl sheets, embedded images exported via image-filter
+    path.
+
+### 3.2 Vision layer (diagram → retrievable text)
+
+- **Pre-filter**: `image_utils.filtering.is_diagram_image` rejects
+  decorative images before any LLM call (area, side length, aspect
+  ratio, page-position heuristic).
+- **Caption hinting**: `image_utils.caption.find_best_caption_for_image`
+  pairs each surviving image with the closest text block as a hint.
+- **Resolution classification**: `vision.prompts.classify_image_quality`
+  → `{clear, low_res, unreadable}` — changes the prompt preamble but
+  still attempts extraction.
+- **Provider adapter**: `vision.describer.VisionDescriber` implements
+  the same `describe(...)` interface for OpenAI Responses API,
+  Anthropic Messages, and Gemini `generateContent`. Returns tuple of
+  `(structured_json, usage_dict)`.
+- **Tiling**: when `image_pixels >= image_large_pixels_threshold`,
+  `vision.tiling.split_image_into_tiles` yields per-tile bytes; each
+  tile is described separately and merged by
+  `output_normalizer.merge_vision_tile_outputs`.
+- **Robustness**:
+  - `extract_json_object` tolerates trailing prose around the JSON.
+  - If `json_parse_fallback_used=True` and `vision_retry_max_tokens`
+    is higher than the first pass, a second call is made with a
+    `retry_note` forcing JSON-only output.
+- **Flattening for RAG**: `build_image_text_content` turns the
+  structured JSON into a single text blob with `image_type`, visible
+  text, description, and structural elements — so the chunk remains
+  semantically rich even after embedding.
+
+### 3.3 Chunking
+
+- Pure-function strategies in `chunking_strategies.py` (research-harness)
+  and `scripts/core/chunking.py` (product).
+- Product chunking: character-based sliding window with word-boundary
+  snapping; deterministic `sha1_id` per chunk so re-ingesting produces
+  stable IDs.
+- Research chunking exposes three strategies (`semantic`, `fixed`,
+  `hybrid`) so the harness can compare them on the same answer set.
+
+### 3.4 Embedding & vector store
+
+- **Local**: run-local Chroma collection under
+  `outputs/<run_id>/chroma_db`. `chroma_store.try_store_chroma` handles
+  creation + insertion; `CHROMA_EMBEDDING_PROVIDER=default` avoids
+  OpenAI quota issues on reviewer machines.
+- **Production**: Azure-hosted vector via `AzureVectorService` +
+  embeddings via `AzureEmbeddingService` (`azure.ai.inference`) or
+  `CohereEmbeddingService`. Three input types:
+  `SEARCH_QUERY`, `IMAGE`, `DOCUMENT` — Cohere is called with
+  `input_type` matching the use case.
+- **Retrieval interface**: `ChromaRAG` (local) and
+  `VectorDBService.search` (abstract) both return `(doc_id, score,
+  metadata, text)` tuples so downstream grading code is
+  provider-agnostic.
+
+### 3.5 Grading
+
+- **Prompt assembly** (`grade_submission.py`):
+  1. System: persona + grading rules + originality policy.
+  2. Context: rubric (verbatim), assignment (verbatim), retrieved
+     lecture chunks (top-k, scored).
+  3. Optional: few-shot calibration block (in the research harness) or
+     task-specific prompt module (e.g. `quiz_1_brp_prompt`).
+  4. Target: the student answer.
+- **Output contract**: per-criterion `{evidence, score}` plus
+  `overall_score`. Enforced via structured-output parsing
+  (Pydantic / JSON schema) in the product.
+- **Cost tracking**: every LLM call flows through `TokenTracker`, which
+  looks up `MODEL_PRICING[model]` and emits
+  `grading_call_cost_usd` alongside token counts.
+- **Provider adapters**: OpenAI, Anthropic, Gemini — cache tokens are
+  tracked where the SDK reports them (Anthropic
+  cache-creation/cache-read; GPT-4o has no cache column).
+
+### 3.6 Rubric refinement
+
+Two-step LLM flow, implemented as a pure pipeline so each step is
+separately auditable:
+
+```
+┌──────────────────────────┐     ┌────────────────────────────┐
+│   Original rubric        │     │   Optional: instructor     │
+│   + assignment           │     │   notes (instructions=...) │
+└──────────────┬───────────┘     └──────────────┬─────────────┘
+               │                                │
+               ▼                                ▼
+     ┌─────────────────────────────────────────────────┐
+     │  critique_rubric(...)  → RubricCritique         │
+     │  (specificity, point distribution, coverage,    │
+     │   clarity, duplication/ambiguity, flags)        │
+     │  CONSTRAINT: must NOT propose a new rubric.     │
+     └─────────────────────────────────────────────────┘
+                        │
+                        ▼
+     ┌─────────────────────────────────────────────────┐
+     │  refine_rubric(original, critique, notes?)      │
+     │      → Rubric                                   │
+     │  CONSTRAINTS:                                   │
+     │   · per-question grading_criteria points SUM    │
+     │     EXACTLY to max_points                        │
+     │   · specific, measurable, objective criteria    │
+     │   · preserve original intent                    │
+     │   · only adjust max_points if strictly needed   │
+     └─────────────────────────────────────────────────┘
+                        │
+                        ▼ (optional persistence)
+              Azure Blob  →  assignment.json + critique.json
+```
+
+Surfaced through `POST /api/v1/ai_rubric_refine` in
+`app/routes/rubric_review.py`. Offline generation (no prior rubric) is
+handled by `scripts/rubric_gen/generate_rubric.py`.
+
+### 3.7 Background processing
+
+`app/services/bg_material_processor.BackgroundMaterialProcessor`:
+
+- Scans `TEMP_FILES_DIR` on a loop for queued work items (JSON files
+  describing a grading or RAG job).
+- Uses `portalocker` so multiple FastAPI workers can't pick up the same
+  job.
+- Runs the RAG ingest and grading pipelines off-thread via
+  `ErrorHandlingThreadPool`, which surfaces task exceptions rather
+  than swallowing them.
+- Rationale: LLM calls are slow and unpredictable, FastAPI workers can
+  be recycled, and a file-based queue survives worker restarts.
+
+### 3.8 Auth
+
+- JWT-based session auth in `app/utils/jwt_service.py` —
+  `JWTService.get_instance().from_authorization_header` is the FastAPI
+  dependency used across protected routes.
+- Personal Access Tokens persisted per user under
+  `user/<email>/tokens/<token_name>.json` in Blob.
+- Google OAuth entry point in `app/routes/auth.py`, gated by
+  `GOOGLE_OAUTH_CLIENT_FILE`.
+- JWT encryption secret is generated by the standalone
+  `generate_jwt_secret.py` — never committed, referenced by
+  `JWT_ENCRYPTION_SECRET_FILE`.
+
+### 3.9 Data-leakage guard (research harness)
+
+- `FEW_SHOT_EXAMPLES` registers anchor answers per assignment, with
+  source semester documented in-file.
+- `run_eval()` computes an 80-char fingerprint per registered anchor
+  and strips any matching eval rows before grading.
+- Assignment ID is auto-inferred from path (`_infer_assignment_id`),
+  so the guard is active in both baseline and few-shot runs → both
+  conditions evaluate the same filtered row set.
+
+---
+
+## 4. Interfaces
+
+### 4.1 REST API (FastAPI)
+
+Base URL: `http://localhost:8000/api/v1` (dev) — Swagger at `/docs`,
+ReDoc at `/redoc`.
+
+| Prefix | Router | Notes |
+| --- | --- | --- |
+| `/api/v1/auth` | `auth.py` | Google OAuth + session. |
+| `/api/v1/...` | `course.py` | Course CRUD. |
+| `/api/v1/...` | `assignment.py` | Assignment CRUD. |
+| `/api/v1/response` | `grading.py` | Trigger grading on a student response. |
+| `/api/v1/...` | `rubric.py` | Rubric CRUD. |
+| `/api/v1/...` | `rubric_review.py` | `POST /ai_rubric_refine`. |
+| `/api/v1/...` | `student_response.py` | Submission CRUD. |
+| `/api/v1/...` | `course_material.py` | Material upload / list / delete. |
+| `/api/v1/...` | `user.py` | User + PAT management. |
+
+All routers are mounted in `app/main.py` with CORS for
+`http://localhost:3000` and `DEPLOYMENT_URL`.
+
+### 4.2 Pipeline CLI
+
+`python app/scripts/cli/run_pipeline.py --mode <stage>` where stage is
+one of `extract | describe | index | retrieve | grade | full | compare`.
+Each mode has its own flag set; see `ml-bu-autograder/README.md` for
+full syntax.
+
+### 4.3 Streamlit MVP
+
+`streamlit run app/scripts/cli/mvp_web.py` — self-contained review app
+that runs the full pipeline per session in a run-local output directory.
+
+### 4.4 Next.js frontend
+
+`frontend/src/pages/`:
+
+- `login.js`, `settings.js`, `courses.js`, `manual_submission.js`
+- `course/[id]/{index, assignments, rubrics, grading, materials,
+  instructors}.js`
+
+Talks to the FastAPI backend via `src/api.js`; theme in
+`ThemeContext.js` + `styles/theme.js`.
+
+### 4.5 Research harness CLI
+
+`python eval_chunking_grading.py --excel ... --rubric ...
+--strategies semantic fixed hybrid --models openai claude gemini`
+and `python run_fewshot_comparison.py` as the higher-level driver.
+
+---
+
+## 5. Storage Layout
+
+### 5.1 Azure Blob container layout (product)
+
+```
+/
+├── course/
+│   └── {semester_key}/                      e.g. Fall2025
+│       └── {course_id}/                     e.g. CS581
+│           ├── course.json
+│           ├── assignment/
+│           │   └── {assignment_id}/
+│           │       ├── assignment.json
+│           │       ├── {question_index}/
+│           │       │   ├── question.json
+│           │       │   └── student_response/
+│           │       │       └── {student_id}/
+│           │       │           ├── response.{ext}
+│           │       │           └── grade.json
+│           │       └── rubrics/
+│           │           ├── assignment.json   (overall rubric)
+│           │           └── {question_index}.json (sub-rubric)
+│           └── course_material/
+│               └── {material_id}.{ext}
+└── user/
+    └── {user_email}/
+        ├── user.json
+        └── tokens/
+            └── {token_name}.json
+```
+
+### 5.2 Local run artifacts
+
+```
+outputs/final_phase1/<run_id>/
+├── extract/                                 per-file extraction JSON
+├── describe_<provider>_<model>/
+│   └── chunks.jsonl                         flattened RAG-ready chunks
+├── chroma_db/                               run-local Chroma
+├── retrieval.jsonl                          top-k results per question
+└── grade.json                               final graded output
+```
+
+### 5.3 Research-harness artifacts
+
+```
+BU MET/
+├── cs581_pptx_index.jsonl                   slide-level RAG index
+├── cs581_lecture_html_index.jsonl           HTML-lecture RAG index
+├── chunking_eval_results*.json              per-run MAE dumps
+└── fewshot_comparison_results.json          baseline-vs-few-shot table
+```
+
+---
+
+## 6. Configuration
+
+Layered configuration, in order of precedence (later wins):
+
+1. Defaults in `scripts/core/config.py`.
+2. `.env` / environment variables (loaded via `python-dotenv`).
+3. CLI flags on `run_pipeline.py` / `mvp_web.py`.
+4. API request parameters (product mode only).
+
+### Key environment variables
+
+| Variable | Scope | Purpose |
+| --- | --- | --- |
+| `OPENAI_API_KEY` | both | OpenAI grading + embeddings. |
+| `ANTHROPIC_API_KEY` | both | Claude grading + vision. |
+| `GEMINI_API_KEY` / `GOOGLE_API_KEY` | both | Gemini grading + embeddings. |
+| `AUTO_GRADER_RUBRIC_DIR` | product | Default rubric library path. |
+| `AUTO_GRADER_LECTURE_CHUNKS` | product | Path to pre-built `chunks.jsonl`. |
+| `CHROMA_EMBEDDING_PROVIDER` | product | `default` keeps Chroma local. |
+| `OPENAI_EMBEDDING_MODEL` | product | e.g. `text-embedding-3-small`. |
+| `GOOGLE_EMBEDDING_MODEL` | product | e.g. `gemini-embedding-001`. |
+| `AZURE_STORAGE_ACCOUNT_NAME`, `AZURE_CONTAINER_NAME` | product | Blob storage target. |
+| `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET` | product | Service principal for `DefaultAzureCredential`. |
+| `AZURE_LLM_DEPLOYMENT_URL`, `AZURE_LLM_DEPLOYMENT_KEY` | product | Azure OpenAI deployment for the `LLMService`. |
+| `AZURE_EMBEDDING_DEPLOYMENT_*`, `AZURE_EMBEDDING_MODEL` | product | Azure embeddings. |
+| `AZURE_SEARCH_ENDPOINT`, `AZURE_SEARCH_API_KEY`, `AZURE_SEARCH_INDEX_NAME`, `AZURE_SEARCH_EMBEDDING_DIMS` | product | Azure AI Search target. |
+| `COHERE_EMBEDDING_KEY` | product | Cohere v2 embeddings. |
+| `JWT_ENCRYPTION_SECRET_FILE` | product | Output of `generate_jwt_secret.py`. |
+| `TEMP_FILES_DIR` | product | Inbox for the background processor. |
+| `DEPLOYMENT_URL` | product | CORS allowlist entry + external base URL. |
+| `PRODUCTION` | product | Toggles log format + strict error paths. |
+
+---
+
+## 7. Runtime Topology
+
+### 7.1 Local reviewer mode
+
+```
+┌───────────────┐        ┌───────────────┐
+│  Streamlit    │──────▶ │  subprocess:  │
+│  mvp_web.py   │        │  run_pipeline │
+└───────┬───────┘        │  (extract →   │
+        │                │   describe →  │
+        │                │   index →     │
+        │                │   retrieve →  │
+        │                │   grade)      │
+        │                └──────┬────────┘
+        ▼                       │
+   UI tiles                     ▼
+                       ┌─────────────────┐
+                       │ Local Chroma    │
+                       │ (per run)       │
+                       └─────────────────┘
+```
+
+No Azure, no auth. Reviewer adds one or more LLM provider keys to
+`app/.env` and points at an existing `chunks.jsonl` or lets `mvp_web`
+build one on the fly.
+
+### 7.2 Full product stack
+
+```
+Browser (Next.js)
+       │
+       ▼
+FastAPI (uvicorn)  ─── JWT verify ── AzureBlobService (course data)
+       │                         ──  LLMService (Azure OpenAI)
+       │                         ──  CohereEmbeddingService
+       │                         ──  ChromaDBService (or Azure Vector)
+       │
+       ├── writes job to TEMP_FILES_DIR  ─── picked up by ───▶
+       │                                                      BackgroundMaterialProcessor
+       │                                                         ├─ RAG ingest
+       │                                                         └─ grading pipeline
+       │                                                               │
+       ▼                                                               ▼
+  Response to user                                             grade.json → Blob
+```
+
+`BackgroundMaterialProcessor.start_task_scan_loop()` is launched in
+`main.py`. Jobs survive worker restarts because they live on disk.
+
+### 7.3 Research-harness mode
+
+```
+shell ─▶ python eval_chunking_grading.py
+         ├── reads Excel + rubric
+         ├── builds in-memory RAG index from cs581_pptx_index.jsonl
+         ├── calls OpenAI / Claude / Gemini directly (no Azure)
+         └── writes chunking_eval_results*.json
+```
+
+---
+
+## 8. Cross-Cutting Concerns
+
+### 8.1 Observability
+
+- **Structured logs** via `app/utils/logging_util.setup_loggers`;
+  `PRODUCTION=true` flips to JSON-friendly output.
+- **Token + cost log**: `TokenTracker` appends per-call records to a
+  persistent JSONL log.
+- **Index HTML** (`scripts/web/templates/index.html` +
+  `app/scripts/web/templates/index.html`) renders the per-call token /
+  cost table for the Flask demo.
+- **Run directories** under `outputs/final_phase1/<run_id>/` are
+  self-contained and easy to zip for postmortems.
+
+### 8.2 Error handling
+
+- FastAPI `ValidationError` and `ValueError` handlers in `main.py`
+  return `400` with the stringified exception.
+- Vision and grading calls fail-soft: invalid JSON → one retry with
+  escalated tokens; persistent failure propagates a structured error
+  rather than crashing the pipeline.
+- `ErrorHandlingThreadPool` ensures background task exceptions are
+  logged instead of silently lost.
+
+### 8.3 Performance & cost
+
+- **Decorative-image filter** (`is_diagram_image`) keeps the vision
+  bill bounded.
+- **Tile merging** avoids over-paying for huge images that would blow
+  past the provider's per-image token caps.
+- **Cache-token pricing** in `MODEL_PRICING` means Anthropic
+  cache-hit reads are priced ~10× cheaper than writes — the grading
+  prompt is designed to exploit this.
+- **Run-local embeddings** (`CHROMA_EMBEDDING_PROVIDER=default`) avoid
+  OpenAI embedding quota issues and keep reviewer demos cheap.
+
+### 8.4 Security
+
+- Secrets (`.env`, JWT secret file, Azure keys) are never committed;
+  `.env-example` documents the required keys.
+- JWT verification on every protected route via the
+  `from_authorization_header` dependency.
+- Azure credentials go through `DefaultAzureCredential` (service
+  principal or managed identity in prod, env-var creds locally).
+- CORS is explicitly allow-listed (`http://localhost:3000` and
+  `DEPLOYMENT_URL`).
+- Academic integrity: originality is a **bounded, separate criterion**
+  in every refined rubric — it cannot silently reduce conceptual
+  scores, and suspected misconduct is flagged rather than
+  auto-penalized.
+
+### 8.5 Testing
+
+- Python unit tests live under `app/tests/` (currently lightweight:
+  `test_bytes_to_doc_util.py`).
+- Rubric E2E regression via `rubric_test/rubric_test.py`.
+- Research-harness runs (MAE dumps) act as integration tests: a
+  regression in chunking, retrieval, or prompt design is visible as a
+  MAE bump in `chunking_eval_results*.json`.
+
+---
+
+## 9. Extension Points
+
+- **Add a grading / vision model.** Append an entry to
+  `scripts/core/token_budget.MODEL_PRICING`; if it's a new provider,
+  extend `VisionDescriber` / `grade_submission` with a branch that
+  matches the existing provider adapters. No other code should need to
+  change.
+- **Add a file type.** Implement an `extract_<type>` + matching
+  `extracted_<type>_to_jsonable` in `scripts/extractors/`, register in
+  the extractors package, and append the extension to
+  `SUPPORTED_EXTENSIONS`.
+- **Add a chunking strategy.** Add a pure function to
+  `chunking_strategies.py` (or `scripts/core/chunking.py`) and wire it
+  into the research-harness `--strategies` choice list.
+- **Add a rubric for a new quiz.** Drop `rubric_refined.txt` +
+  `quiz_{N}.json` into `New Refined Rubrics/quiz_{N}/`, then add a
+  `FEW_SHOT_EXAMPLES["quiz_{N}"]` entry (with documented source
+  semester) in `eval_chunking_grading.py`.
+- **Swap vector backends.** `VectorDBService` is the abstract
+  interface; implement it for a new store and wire it into
+  `bg_material_processor` in place of `ChromaDBService`.
+
+---
+
+## 10. Design Decisions Worth Flagging
+
+1. **Two copies of `scripts/`** (root and `app/scripts/`) are kept
+   intentionally so the CLI can run without the FastAPI stack
+   installed. The `app/scripts/` version is canonical.
+2. **File-based job queue** (not Celery / RQ) to keep the local
+   review path trivial — nothing extra to install.
+3. **Structured vision output over plain captioning** so each diagram
+   produces both verbatim text (for exact retrieval matches) and a
+   natural-language description (for semantic retrieval).
+4. **Rubric refinement is strictly two-step** so point-sum drift can
+   only happen in the revise step, which is explicitly constrained to
+   preserve `max_points`.
+5. **Originality as a separate, bounded criterion** rather than a
+   multiplier — prevents the LLM from compounding a wording penalty
+   with a conceptual penalty.
+6. **Data-leakage guard defaults to on** based on path inference. There
+   is no way to accidentally run a few-shot eval without the filter.
+7. **Research harness writes JSON, not markdown.** All "experiment
+   results" are diffable and re-processable.
+
+---
+
+## 11. Known Limitations
+
+- `text-embedding-ada-002` access issues on some OpenAI projects; swap
+  to `text-embedding-3-small` in `embed_chunks` or use the local
+  Chroma default embedder.
+- The background processor relies on a polling loop; latency is
+  bounded by its scan interval, not sub-second.
+- Refined rubrics currently cover Quiz 1–4; the Final Exam is not yet
+  refined.
+- OCR is Tesseract-based and only kicks in when vision mode is off —
+  no hybrid OCR-then-vision path today.
+
+---
+
+## 12. Related Documentation
+
+- [`README.md`](README.md) — setup and quickstart.
+- [`FEATURES_AND_FILES.md`](FEATURES_AND_FILES.md) — features &
+  per-file catalog.
+- `ml-bu-autograder/README.md` — product-side quickstart.
+- `ml-bu-autograder/MANIFEST.md` — full product-repo inventory.
+- `ml-bu-autograder/PLAN.md` — roadmap.
+- `ml-bu-autograder/CALIBRATION_*.md` — calibration writeups.
+- `ml-bu-autograder/Josh Yip - Azure Documentation.md` — Azure setup
+  detail.


### PR DESCRIPTION
## Summary

Adds two top-level documentation files for the project.

- **`FEATURES_AND_FILES.md`** — feature and research inventory, plus a
  per-file catalog of every Python module across `app/` and
  `app/scripts/` (routes, models, services, utilities, extractors,
  vision, image utils, retrieval, storage, grading, rubric_gen,
  exporters, tools, web). Also covers the rubric-refinement effort
  (critique → revise) and the data-leakage guard used during
  calibration.
- **`SYSTEM_DESIGN.md`** — architecture overview, end-to-end data
  flow (`extract → filter → describe → flatten → chunk → index →
  retrieve → grade`), per-subsystem breakdowns (extraction, vision,
  chunking, embeddings/vector store, grading, rubric refinement,
  background processor, auth, leakage guard), interface matrix
  (REST / pipeline CLI / Streamlit MVP / Next.js frontend), Azure
  Blob and run-local storage layouts, layered configuration plus a
  complete env-var table, three runtime-topology diagrams (local
  reviewer / full product stack / research-harness), cross-cutting
  concerns (observability, error handling, performance/cost,
  security, testing), extension points, and known limitations.

No code changes — documentation only.

## Caveats

Both documents were drafted from a parent workspace that contains a
companion research harness (`eval_chunking_grading.py`,
`run_fewshot_comparison.py`, etc.) living outside this repo, so a few
references point to files that don't exist in `BU-Spark/ml-bu-autograder`:

- Part 2.1 of `FEATURES_AND_FILES.md` lists those workspace-only files.
- `SYSTEM_DESIGN.md` shows both the product data flow and a
  separate, simpler research-harness flow.
- Cross-links to `README.md` in each doc assume a workspace-level
  README that isn't in this repo (the product's own `README.md`
  plays a different role).

If the team prefers a version that's scoped strictly to this repo, I'm
happy to trim those sections in a follow-up commit before merging.
Kept as-is for now so the broader project context is preserved.

## Test plan

- [ ] Render both `.md` files on GitHub and confirm headings,
      tables, code blocks, and ASCII diagrams look correct.
- [ ] Spot-check a handful of file references in
      `FEATURES_AND_FILES.md` Part 2 against the actual file tree.
- [ ] Confirm cross-doc links between `FEATURES_AND_FILES.md` and
      `SYSTEM_DESIGN.md` resolve.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive system design documentation outlining the autograder architecture, operational pipeline, subsystems, and deployment topology.
  * Added feature and file catalog guide documenting product capabilities, codebase organization, configuration conventions, and design decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->