### PR TITLE
feat(grading): few-shot exemplars in main grader (AUTO_GRADER_FEW_SHOT_FILE)

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -26,6 +26,8 @@ ENV_TEST_API_KEY=
 # Environment variables for the LLM API to use (e.g. gpt-4o-mini)
 AZURE_LLM_DEPLOYMENT_URL=  # URL should look like this: https://{your_project}.openai.azure.com/openai/deployments/{deployment_model}/chat/completions?api-version={api_version}
 AZURE_LLM_DEPLOYMENT_KEY=
+# Optional: path to a .txt with few-shot exemplars appended to the grader system prompt (can reduce MSE vs human)
+# AUTO_GRADER_FEW_SHOT_FILE=
 # Environment variables for the audio transcription model
 AZURE_AUDIO_TRANSCRIPTION_ENDPOINT=
 AZURE_AUDIO_TRANSCRIPTION_KEY=

--- a/app/services/bg_material_processor.py
+++ b/app/services/bg_material_processor.py
@@ -3,6 +3,7 @@ import base64
 import logging
 import os
 import random
+from pathlib import Path
 from typing import Optional, TextIO, Callable, Dict, List
 from itertools import chain
 
@@ -29,6 +30,50 @@ The reason we do it like this is because:
 4. In production, there might be multiple processes of FastAPI that are truly parallel so this
    approach has the added advantage of true multi-threading (not usually easily possible in Python).
 """
+
+FEW_SHOT_ENV = "AUTO_GRADER_FEW_SHOT_FILE"
+_FEW_SHOT_MAX_CHARS = 16_000
+
+_BASE_SYSTEM_PROMPT = (
+    "You are a grader responsible for grading a student's response "
+    "ensuring accuracy and fairness."
+)
+
+
+def _load_few_shot_exemplars() -> str:
+    """
+    Optional few-shot / calibration text appended to the grader system message.
+    Set AUTO_GRADER_FEW_SHOT_FILE in the environment to a plain-text path (absolute recommended).
+    """
+    raw = os.getenv(FEW_SHOT_ENV, "").strip()
+    if not raw:
+        return ""
+    p = Path(raw).expanduser()
+    if not p.is_file():
+        logging.warning("%s is not a readable file: %s", FEW_SHOT_ENV, p)
+        return ""
+    try:
+        text = p.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        logging.warning("Could not read %s: %s", p, e)
+        return ""
+    if len(text) > _FEW_SHOT_MAX_CHARS:
+        logging.warning("Few-shot file truncated from %d to %d characters.", len(text), _FEW_SHOT_MAX_CHARS)
+        text = text[:_FEW_SHOT_MAX_CHARS]
+    return text.strip()
+
+
+def _grader_system_prompt() -> str:
+    extra = _load_few_shot_exemplars()
+    if not extra:
+        return _BASE_SYSTEM_PROMPT
+    return (
+        _BASE_SYSTEM_PROMPT
+        + "\n\n=== FEW-SHOT EXEMPLARS (calibration) ===\n"
+        "The following examples illustrate desired grading style and rubric application. "
+        "Follow this spirit; the rubric and student response content in the user messages remain authoritative.\n\n"
+        + extra
+    )
 
 
 def process_grading(json_str: str):
@@ -93,8 +138,7 @@ def process_grading(json_str: str):
     #          assignment instructions, rubric, RAG-ed course material chunks, and student
     #          response to generate a prompt for auto-grading.
     prompt = (PromptBuilder.builder()
-              .add_message(PromptRole.SYSTEM, "You are a grader responsible for grading a student's response "
-                                              "ensuring accuracy and fairness.")
+              .add_message(PromptRole.SYSTEM, _grader_system_prompt())
               .add_message(PromptRole.USER, "Here is course material that might be relevant to this assignment."
                                             "When evaluating accuracy for your grades, in your grading responses, "
                                             "cite these relevant sources including with any in the following format: "


### PR DESCRIPTION
Adds optional in-context few-shot / calibration text to the **main** background grading path (`process_grading` in `bg_material_processor.py`).

- Set `AUTO_GRADER_FEW_SHOT_FILE` to a plain-text file path; content is appended to the grader system message under a `FEW-SHOT EXEMPLARS` block (16k char cap).
- Documented in `.env-example`.

**Note:** Direct push to `dev` is branch-protected; open this PR to merge into `dev`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grader now supports optional few-shot exemplars loaded from a plaintext calibration file. System includes automatic file validation and truncation, reverting to default behavior if configuration is unavailable or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->